### PR TITLE
remove spring dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,8 @@
 
     <properties>
         <checkstyle.config>${project.basedir}/src/test/resources/io/tarantool/driver/checkstyle.xml</checkstyle.config>
-        <checkstyle.suppressions>${project.basedir}/src/test/resources/io/tarantool/driver/suppressions.xml</checkstyle.suppressions>
+        <checkstyle.suppressions>${project.basedir}/src/test/resources/io/tarantool/driver/suppressions.xml
+        </checkstyle.suppressions>
         <logging.config>${project.basedir}/src/test/resources/logback-test.xml</logging.config>
         <logging.logLevel>debug</logging.logLevel>
     </properties>
@@ -176,11 +177,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <version>5.2.6.RELEASE</version>
-        </dependency>
-        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
             <version>4.1.50.Final</version>
@@ -190,6 +186,14 @@
             <artifactId>msgpack-core</artifactId>
             <version>0.8.20</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -218,7 +222,8 @@
                                 <manifestEntries>
                                     <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
                                     <Bundle-Name>${project.name}</Bundle-Name>
-                                    <Bundle-SymbolicName>${project.groupId}.${project.artifactId}.source</Bundle-SymbolicName>
+                                    <Bundle-SymbolicName>${project.groupId}.${project.artifactId}.source
+                                    </Bundle-SymbolicName>
                                     <Bundle-Vendor>${project.organization.name}</Bundle-Vendor>
                                 </manifestEntries>
                             </archive>

--- a/src/main/java/io/tarantool/driver/StandaloneTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/StandaloneTarantoolClient.java
@@ -19,7 +19,7 @@ import io.tarantool.driver.core.RequestFutureManager;
 import io.tarantool.driver.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.space.TarantoolSpace;
 import io.tarantool.driver.space.TarantoolSpaceOperations;
-import org.springframework.util.Assert;
+import io.tarantool.driver.util.Assert;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;

--- a/src/main/java/io/tarantool/driver/api/TarantoolIndexQuery.java
+++ b/src/main/java/io/tarantool/driver/api/TarantoolIndexQuery.java
@@ -1,7 +1,7 @@
 package io.tarantool.driver.api;
 
 import io.tarantool.driver.protocol.TarantoolIteratorType;
-import org.springframework.util.Assert;
+import io.tarantool.driver.util.Assert;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/io/tarantool/driver/api/TarantoolSelectOptions.java
+++ b/src/main/java/io/tarantool/driver/api/TarantoolSelectOptions.java
@@ -1,6 +1,6 @@
 package io.tarantool.driver.api;
 
-import org.springframework.util.Assert;
+import io.tarantool.driver.util.Assert;
 
 /**
  * Represents common tuple selection options not related to the index and filtration, e.g. limit and offset

--- a/src/main/java/io/tarantool/driver/api/tuple/TarantoolFieldImpl.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/TarantoolFieldImpl.java
@@ -3,9 +3,9 @@ package io.tarantool.driver.api.tuple;
 import io.tarantool.driver.exceptions.TarantoolValueConverterNotFoundException;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.mappers.MessagePackValueMapper;
+import io.tarantool.driver.util.Nullable;
 import org.msgpack.value.Value;
 import org.msgpack.value.ValueFactory;
-import org.springframework.lang.Nullable;
 
 import java.math.BigDecimal;
 import java.util.UUID;

--- a/src/main/java/io/tarantool/driver/api/tuple/TarantoolNullField.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/TarantoolNullField.java
@@ -1,9 +1,9 @@
 package io.tarantool.driver.api.tuple;
 
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
+import io.tarantool.driver.util.Nullable;
 import org.msgpack.value.Value;
 import org.msgpack.value.ValueFactory;
-import org.springframework.lang.Nullable;
 
 import java.math.BigDecimal;
 import java.util.UUID;

--- a/src/main/java/io/tarantool/driver/api/tuple/TarantoolTupleImpl.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/TarantoolTupleImpl.java
@@ -3,9 +3,9 @@ package io.tarantool.driver.api.tuple;
 import io.tarantool.driver.exceptions.TarantoolValueConverterNotFoundException;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.mappers.MessagePackValueMapper;
+import io.tarantool.driver.util.Assert;
 import org.msgpack.value.ArrayValue;
 import org.msgpack.value.Value;
-import org.springframework.util.Assert;
 
 import java.util.ArrayList;
 import java.util.Iterator;

--- a/src/main/java/io/tarantool/driver/api/tuple/package-info.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/package-info.java
@@ -1,5 +1,7 @@
 /**
  * Contains tuple representation classes and helpers
  */
-@org.springframework.lang.NonNullApi
+@NonNullApi
 package io.tarantool.driver.api.tuple;
+
+import io.tarantool.driver.util.NonNullApi;

--- a/src/main/java/io/tarantool/driver/auth/ChapSha1TarantoolAuthenticator.java
+++ b/src/main/java/io/tarantool/driver/auth/ChapSha1TarantoolAuthenticator.java
@@ -1,7 +1,8 @@
 package io.tarantool.driver.auth;
 
-import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
+
+import io.tarantool.driver.util.Assert;
+import io.tarantool.driver.util.StringUtils;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;

--- a/src/main/java/io/tarantool/driver/auth/SimpleTarantoolCredentials.java
+++ b/src/main/java/io/tarantool/driver/auth/SimpleTarantoolCredentials.java
@@ -1,6 +1,6 @@
 package io.tarantool.driver.auth;
 
-import org.springframework.util.Assert;
+import io.tarantool.driver.util.Assert;
 
 /**
  * Container for plain user and password data for authentication

--- a/src/main/java/io/tarantool/driver/mappers/DefaultMessagePackMapper.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultMessagePackMapper.java
@@ -1,7 +1,7 @@
 package io.tarantool.driver.mappers;
 
+import io.tarantool.driver.util.Nullable;
 import org.msgpack.value.Value;
-import org.springframework.lang.Nullable;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/src/main/java/io/tarantool/driver/mappers/package-info.java
+++ b/src/main/java/io/tarantool/driver/mappers/package-info.java
@@ -3,5 +3,7 @@
  *
  * @author Alexey Kuzin
  */
-@org.springframework.lang.NonNullApi
+@NonNullApi
 package io.tarantool.driver.mappers;
+
+import io.tarantool.driver.util.NonNullApi;

--- a/src/main/java/io/tarantool/driver/metadata/TarantoolMetadata.java
+++ b/src/main/java/io/tarantool/driver/metadata/TarantoolMetadata.java
@@ -6,7 +6,7 @@ import io.tarantool.driver.api.TarantoolIndexQuery;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.TarantoolSelectOptions;
 import io.tarantool.driver.protocol.TarantoolIteratorType;
-import org.springframework.util.Assert;
+import io.tarantool.driver.util.Assert;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/io/tarantool/driver/metadata/package-info.java
+++ b/src/main/java/io/tarantool/driver/metadata/package-info.java
@@ -3,5 +3,7 @@
  *
  * @author Alexey Kuzin
  */
-@org.springframework.lang.NonNullApi
+@NonNullApi
 package io.tarantool.driver.metadata;
+
+import io.tarantool.driver.util.NonNullApi;

--- a/src/main/java/io/tarantool/driver/protocol/TarantoolHeader.java
+++ b/src/main/java/io/tarantool/driver/protocol/TarantoolHeader.java
@@ -1,11 +1,11 @@
 package io.tarantool.driver.protocol;
 
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
+import io.tarantool.driver.util.Nullable;
 import org.msgpack.value.IntegerValue;
 import org.msgpack.value.MapValue;
 import org.msgpack.value.Value;
 import org.msgpack.value.ValueFactory;
-import org.springframework.lang.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/io/tarantool/driver/protocol/package-info.java
+++ b/src/main/java/io/tarantool/driver/protocol/package-info.java
@@ -3,5 +3,7 @@
  *
  * @author Alexey Kuzin
  */
-@org.springframework.lang.NonNullApi
+@NonNullApi
 package io.tarantool.driver.protocol;
+
+import io.tarantool.driver.util.NonNullApi;

--- a/src/main/java/io/tarantool/driver/protocol/requests/TarantoolAuthRequest.java
+++ b/src/main/java/io/tarantool/driver/protocol/requests/TarantoolAuthRequest.java
@@ -7,7 +7,7 @@ import io.tarantool.driver.protocol.TarantoolProtocolException;
 import io.tarantool.driver.protocol.TarantoolRequest;
 import io.tarantool.driver.protocol.TarantoolRequestBody;
 import io.tarantool.driver.protocol.TarantoolRequestType;
-import org.springframework.util.Assert;
+import io.tarantool.driver.util.Assert;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/src/main/java/io/tarantool/driver/protocol/requests/package-info.java
+++ b/src/main/java/io/tarantool/driver/protocol/requests/package-info.java
@@ -3,5 +3,7 @@
  *
  * @author Alexey Kuzin
  */
-@ org.springframework.lang.NonNullApi
+@NonNullApi
 package io.tarantool.driver.protocol.requests;
+
+import io.tarantool.driver.util.NonNullApi;

--- a/src/main/java/io/tarantool/driver/space/package-info.java
+++ b/src/main/java/io/tarantool/driver/space/package-info.java
@@ -3,5 +3,7 @@
  *
  * @author Alexey Kuzin
  */
-@org.springframework.lang.NonNullApi
+@NonNullApi
 package io.tarantool.driver.space;
+
+import io.tarantool.driver.util.NonNullApi;

--- a/src/main/java/io/tarantool/driver/util/Assert.java
+++ b/src/main/java/io/tarantool/driver/util/Assert.java
@@ -1,0 +1,24 @@
+package io.tarantool.driver.util;
+
+
+public class Assert {
+
+    public static void state(boolean expression, String message) {
+        if (!expression) {
+            throw new IllegalStateException(message);
+        }
+    }
+
+    public static void hasText(@Nullable String text, String message) {
+        if (!StringUtils.hasText(text)) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+    public static void notNull(@Nullable Object o, String message) {
+        if (o == null) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+}

--- a/src/main/java/io/tarantool/driver/util/NonNullApi.java
+++ b/src/main/java/io/tarantool/driver/util/NonNullApi.java
@@ -1,0 +1,13 @@
+package io.tarantool.driver.util;
+
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierDefault;
+import java.lang.annotation.*;
+
+/** copy&paste from mongo driver */
+@Target(ElementType.PACKAGE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Nonnull
+@TypeQualifierDefault({ElementType.METHOD, ElementType.PARAMETER})
+public @interface NonNullApi {}

--- a/src/main/java/io/tarantool/driver/util/Nullable.java
+++ b/src/main/java/io/tarantool/driver/util/Nullable.java
@@ -1,0 +1,14 @@
+package io.tarantool.driver.util;
+
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierNickname;
+import javax.annotation.meta.When;
+import java.lang.annotation.*;
+
+/** copy&paste from mongo driver */
+@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Nonnull(when = When.MAYBE)
+@TypeQualifierNickname
+public @interface Nullable {}

--- a/src/main/java/io/tarantool/driver/util/StringUtils.java
+++ b/src/main/java/io/tarantool/driver/util/StringUtils.java
@@ -1,0 +1,22 @@
+package io.tarantool.driver.util;
+
+
+public class StringUtils {
+
+    public static boolean hasText(@Nullable String str) {
+        return str != null && !str.isEmpty() && containsText(str);
+    }
+
+    private static boolean containsText(CharSequence str) {
+        int strLen = str.length();
+
+        for (int i = 0; i < strLen; ++i) {
+            if (!Character.isWhitespace(str.charAt(i))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}


### PR DESCRIPTION
Using spring framework only for nullability support and assert utils looks strange. Half of java projects in the wild do not use spring at all and this dependency looks too heavyweight. But another half of projects may have even bigger problems due to this dependency from version conflicts.