### PR TITLE
Fix upsert operations serialization

### DIFF
--- a/src/main/java/io/tarantool/driver/api/tuple/operations/TupleSpliceOperation.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/operations/TupleSpliceOperation.java
@@ -51,7 +51,9 @@ public class TupleSpliceOperation extends TupleUpdateOperation {
     @Override
     public Value toMessagePackValue(MessagePackObjectMapper mapper) {
         return mapper.toValue(Arrays.asList(
-                getOperationType().toString(), getFieldIndex(), getPosition(), getOffset(), getValue()));
+                getOperationType().toString(),
+                getFieldIndex() != null ? getFieldIndex() : getFieldName(),
+                getPosition(), getOffset(), getValue()));
     }
 
     public int getPosition() {

--- a/src/main/java/io/tarantool/driver/api/tuple/operations/TupleUpdateOperation.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/operations/TupleUpdateOperation.java
@@ -62,7 +62,9 @@ abstract class TupleUpdateOperation implements TupleOperation {
     @Override
     public Value toMessagePackValue(MessagePackObjectMapper mapper) {
         return mapper.toValue(
-                Arrays.asList(getOperationType().toString(), getFieldIndex(), getValue()));
+                Arrays.asList(getOperationType().toString(),
+                        getFieldIndex() != null ? getFieldIndex() : getFieldName(),
+                        getValue()));
     }
 
     @Override

--- a/src/test/java/io/tarantool/driver/api/tuple/operations/TupleOperationsTest.java
+++ b/src/test/java/io/tarantool/driver/api/tuple/operations/TupleOperationsTest.java
@@ -5,10 +5,13 @@ import io.tarantool.driver.DefaultTarantoolTupleFactory;
 import io.tarantool.driver.api.TarantoolTupleFactory;
 import io.tarantool.driver.api.tuple.TarantoolField;
 import io.tarantool.driver.api.tuple.TarantoolNullField;
+import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.exceptions.TarantoolSpaceOperationException;
 import io.tarantool.driver.mappers.DefaultMessagePackMapperFactory;
 
 import org.junit.jupiter.api.Test;
+import org.msgpack.value.Value;
+import org.msgpack.value.ValueFactory;
 
 import java.util.Arrays;
 import java.util.List;
@@ -123,5 +126,44 @@ public class TupleOperationsTest {
                 .collect(Collectors.toList());
         assertEquals(Arrays.asList(0, 1, 2), fieldNumbers);
         assertEquals(new TarantoolNullField(), operations.asList().get(2).getValue());
+    }
+
+    @Test
+    public void test_tupleOperations_shouldSerializeCorrectly_ifFieldIsDefinedByName() {
+        final String FIELD_DATA = "data";
+        List<String> object = Arrays.asList("test1", "test2");
+
+        final String FIELD_TS = "ts";
+        Long epochSecond = 12345L;
+
+        final String FIELD_SPLICE = "test";
+
+        TupleOperations tupleOperations = TupleOperations
+                .set(FIELD_DATA, object)
+                .andSet(FIELD_TS, epochSecond)
+                .andSplice(FIELD_SPLICE, 1, 2, "rep");
+
+        Value value = mapperFactory.defaultComplexTypesMapper().toValue(tupleOperations.asProxyOperationList());
+
+        Value cond1 = ValueFactory.newArray(
+                ValueFactory.newString("="),
+                ValueFactory.newString(FIELD_DATA),
+                ValueFactory.newArray(ValueFactory.newString(object.get(0)), ValueFactory.newString(object.get(1))));
+
+        Value cond2 = ValueFactory.newArray(
+                ValueFactory.newString("="),
+                ValueFactory.newString(FIELD_TS),
+                ValueFactory.newInteger(epochSecond));
+
+        Value cond3 = ValueFactory.newArray(
+                ValueFactory.newString(":"),
+                ValueFactory.newString(FIELD_SPLICE),
+                ValueFactory.newInteger(1),
+                ValueFactory.newInteger(2),
+                ValueFactory.newString("rep"));
+
+        Value expected = ValueFactory.newArray(cond1, cond2, cond3);
+
+        assertEquals(expected, value);
     }
 }


### PR DESCRIPTION
This PR fixes serialization of TupleUpdateOperation and TupleSpliceOperation when field name is set. Closes #139 