### PR TITLE
Use JDK 11 with  release option for JDK 8

### DIFF
--- a/.github/workflows/tests-ce.yml
+++ b/.github/workflows/tests-ce.yml
@@ -14,18 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tarantool-version: [ "1.x", "2.10.6"]
+        tarantool-version: [ "1.x", "2.11.6"]
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 11
+      uses: actions/setup-java@v5
       with:
-        java-version: 1.8
+        java-version: 11
+        distribution: zulu
 
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4.2.0
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/tests-ee.yml
+++ b/.github/workflows/tests-ee.yml
@@ -15,13 +15,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 11
+      uses: actions/setup-java@v5
       with:
-        java-version: 1.8
+        java-version: 11
+        distribution: zulu
 
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4.2.0
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>io.tarantool</groupId>
     <artifactId>cartridge-driver</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.14.3</version>
 
     <licenses>
         <license>
@@ -49,7 +49,7 @@
         <connection>scm:git:git@github.com/tarantool/cartridge-java.git</connection>
         <developerConnection>scm:git:git@github.com:tarantool/cartridge-java.git</developerConnection>
         <url>http://github.com/tarantool/cartridge-java/tree/master</url>
-      <tag>v0.13.0</tag>
+      <tag>v0.14.3</tag>
     </scm>
 
     <properties>
@@ -175,7 +175,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
                     <autoReleaseAfterClose>false</autoReleaseAfterClose>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -68,16 +68,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <compilerVersion>1.8</compilerVersion>
                     <fork>true</fork>
                     <debug>true</debug>
                     <optimize>true</optimize>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
-                    <source>8</source>
-                    <target>8</target>
+                    <release>8</release> 
                     <excludes>
                         <exclude>**/package-info.java</exclude>
                     </excludes>
@@ -96,8 +94,8 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <!-- Enforce JDK 1.8+ for compilation. -->
-                                    <version>[1.8.0,)</version>
+                                    <!-- Enforce JDK 1.11+ for compilation. -->
+                                    <version>[1.11.0,)</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>[3.1.1,)</version>
@@ -502,11 +500,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>sonatype-nexus-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
         <repository>
             <id>sonatype-nexus-staging</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>io.tarantool</groupId>
     <artifactId>cartridge-driver</artifactId>
     <packaging>jar</packaging>
-    <version>0.14.3</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/src/main/java/io/tarantool/driver/api/space/options/crud/OperationWithYieldEveryOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/crud/OperationWithYieldEveryOptions.java
@@ -10,8 +10,8 @@ public interface OperationWithYieldEveryOptions<T extends OperationWithYieldEver
     extends Options, Self<T> {
 
     /**
-     * Sets number of tuples processed on storage to yield after, "yield_every" should be > 0.
-     * @param yieldEvery number of tuples processed on storage to yield after, "yield_every" should be > 0.
+     * Sets number of tuples processed on storage to yield after, "yield_every" should be &gt; 0.
+     * @param yieldEvery number of tuples processed on storage to yield after, "yield_every" should be &gt; 0.
      * @return this option instance.
      * @throws IllegalArgumentException {@code if yieldEvery < 0}.
      */


### PR DESCRIPTION
Without this option, the compiled binaries are different from those generated by the JDK 8 and this breaks ancient libraries like Spark 2.4.x when it is used together with the newer driver versions. 